### PR TITLE
Add example prerequisites section for running demo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ To run the example scripts, install these packages:
 pip install pandas scikit-learn seaborn
 ```
 
+These are required to:
+
+- 📊 Handle tabular data (`pandas`)  
+- 🤖 Use ML tools and utilities (`scikit-learn`)  
+- 🧬 Load example datasets like `iris`, `titanic` (`seaborn`)  
+
+> 📌 **Note:** These dependencies are only needed for examples and demos. If you're using `etsi-failprint` in your own pipeline, you likely already have these installed.
+
+
 ---
 
 ## 🏁 Quick Start


### PR DESCRIPTION
🔧 Add Example Prerequisites Section to README
This PR adds a new ⚡ Example Prerequisites section to the README, outlining the necessary Python packages to run the included demo scripts.

📦 Added Packages:
pandas – for tabular data handling

scikit-learn – for ML tools and utilities

seaborn – for loading example datasets (like iris, titanic)

ℹ️ Note: These dependencies are only needed to run the examples and are not required if you're integrating etsi-failprint into an existing pipeline.

Closes #12 ✅

Let me know if you'd like a version with emojis removed or made simpler.