### PR TITLE
Fix: Correct drift correlation logic in compute_drift_correlation

### DIFF
--- a/etsi/failprint/core.py
+++ b/etsi/failprint/core.py
@@ -31,7 +31,7 @@ def analyze(X: pd.DataFrame, y_true: pd.Series, y_pred: pd.Series,
     clusters = cluster_failures(failed_X) if cluster else None
 
     # Step 4: Optional drift correlation
-    drift_corr = compute_drift_correlation(X, y_true, drift_scores) if drift_scores else {}
+    drift_corr = compute_drift_correlation(X, y_true, y_pred, drift_scores) if drift_scores else {}
 
     # Step 5: Write markdown report + logs
     report = ReportWriter(

--- a/etsi/failprint/correlate.py
+++ b/etsi/failprint/correlate.py
@@ -1,8 +1,8 @@
-def compute_drift_correlation(X, y_true, drift_scores: dict):
+def compute_drift_correlation(X, y_true, y_pred, drift_scores: dict):
     if not drift_scores:
         return {}
 
-    failed_idx = y_true != y_true  # Dummy fallback
+    failed_idx = y_true != y_pred  # Dummy fallback
     failed = X[failed_idx]
 
     corr = {}


### PR DESCRIPTION
## Description  
This PR fixes a bug in the drift correlation feature of ``etsi/failprint/correlate.py``. Previously the function attempted to identify failed predictions using ``y_true != y_true``, which always resulted in an empty set, so the drift correlation calculation logic was ineffective. The logic is now corrected to use ``y_true != y_pred`` as intended.

## Changes made
- Updated the signature of ``compute_drift_correlation`` to accept ``y_pred``
- Changed the logic to compute failed indices using ``y_true != y_pred``
- Updated the function call in ``core.py`` to pass ``y_pred``

Let me know if u want to add or change anything!