### PR TITLE
Add BSD 2-Clause License Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,42 @@ We welcome community contributions! Here are some ideas for future enhancements:
 
 ---
 
-## 🗂️ License
+## 📄 License
 
-This project is licensed under the MIT License.
+This project is licensed under the BSD 2-Clause License.
 
+<details>
+<summary>📜 Click here to view full license</summary>
+
+<br>
+
+    BSD 2-Clause License
+
+    Copyright (c) 2025, et-si.ai
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+    THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+</details>
 ---
 
-Made with ❤️ by the etsi-ai team
+> Made with ❤️ by the etsi-ai team
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ This project is licensed under the BSD 2-Clause License.
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 </details>
+
 ---
 
 > Made with ❤️ by the etsi-ai team


### PR DESCRIPTION
This PR adds a "License" section at the bottom of the README to clearly mention the BSD 2-Clause License under which the project is distributed.

✅ What's Added:
Included a collapsible

Details
block containing the full BSD 2-Clause License.
Added a user-friendly message: "📜 Click here to view full license" for better readability.

Helps users and contributors understand the terms of usage and distribution more easily.

🧑‍💻 Motivation:
This improves the professionalism and transparency of the project and ensures licensing is clearly communicated, especially for new contributors.

This pull request addresses and closes issue #7 and #22  by adding the full BSD 2-Clause License in a collapsible section at the end of the README. 📝✅

You can close both #7 and #22 issue after this as it resolves both of the problem with one pr 

@Romit23 Please check this 